### PR TITLE
Fix typos, correct erroneous `@tag` conversions

### DIFF
--- a/trap/James Introcaso; 20 New Traps.json
+++ b/trap/James Introcaso; 20 New Traps.json
@@ -14,7 +14,7 @@
 				]
 			}
 		],
-		"dateAdded": 1581466476
+		"dateAdded": 1581466476,
 		"dateLastModified": 1585422724
 	},
 	"trap": [

--- a/trap/James Introcaso; 20 New Traps.json
+++ b/trap/James Introcaso; 20 New Traps.json
@@ -14,8 +14,8 @@
 				]
 			}
 		],
-		"dateAdded": 1581466476,
-		"dateLastModified": 1584188881
+		"dateAdded": 1581466476
+		"dateLastModified": 1585422724
 	},
 	"trap": [
 		{
@@ -92,7 +92,7 @@
 			"trapHazType": "MAG",
 			"entries": [
 				"This trap appears in 10-foot wide and smaller corridors. Stone arms are carved into the walls. A character notices subtle movement in the arms with a DC 15 Wisdom ({@skill Perception}) check. Creatures wearing a special amulet designed by the trap's maker can move through the corridor without triggering the trap.",
-				"When a creature has moved to the center of the corridor, the trap is triggered. At the start of the round the arms make attack rolls with a {@atk 5|+5 bonus}, grasping at all creatures adjacent to the walls of the corridor. A successful attack deals 11 ({@dice 2d10}) bludgeoning damage to a creature and it is {@condition grappled} by the arms (escape DC 14). While grappled in this way the creature is also {@condition restrained}.",
+				"When a creature has moved to the center of the corridor, the trap is triggered. At the start of the round the arms make attack rolls with a {@hit 5|+5 bonus}, grasping at all creatures adjacent to the walls of the corridor. A successful attack deals 11 ({@dice 2d10}) bludgeoning damage to a creature and it is {@condition grappled} by the arms (escape DC 14). While grappled in this way the creature is also {@condition restrained}.",
 				"Dealing 10 damage to the arms grasping a creature with a single attack or spell causes the arms to let go of that creature (AC 17)."
 			]
 		},
@@ -158,7 +158,7 @@
 			"trapHazType": "MECH",
 			"entries": [
 				"A large scythe drops from the ceiling and swings back and forth in a line 5 feet wide and 20 feet long when a hidden pressure plate in the room is pressed. Any weight of more than 20 pounds placed on the pressure plate triggers the trap. The pressure plate can be spotted with a DC 15 Wisdom ({@skill Perception}) check. A character studying the area can determine the pressure plate is a slightly different color than the rest of the floor with a DC 15 Intelligence ({@skill Investigation}) check and that the ceiling holds the outline of a trapdoor (from which the trap's blade springs forth) with a DC 20 Intelligence ({@skill Investigation}) check. Wedging an {@item iron spike|phb} or other object under the pressure plate prevents the trap from activating and attempting to open the compartment in the ceiling results in the trap activating.",
-				"Once the trap is triggered it acts at the start of every round. The scythe makes an attack roll against creatures in its path with a {@atk 7|+7 bonus} to attack. On a hit the attack deals 33 ({@dice 6d10}) slashing damage.",
+				"Once the trap is triggered it acts at the start of every round. The scythe makes an attack roll against creatures in its path with a {@hit 7|+7 bonus} to attack. On a hit the attack deals 33 ({@dice 6d10}) slashing damage.",
 				"Some pressure plates are triggered to activate multiple pendulum scythes in a room or hall each of which runs along a different line and gets to make its own attacks at the start of the round."
 			]
 		},
@@ -171,7 +171,7 @@
 				"A nozzle connected to a vial of poison gas is hidden within a chest's lock or in something else that a creature might open. Opening the object without the proper key causes the nozzle to spring out, spraying poison.",
 				"When the trap is triggered the nozzle creates a 15-foot cone of gas originating from the lock. Creatures within the cone must make a DC 15 Constitution saving throw. Creatures who fail take 22 ({@dice 4d10}) poison damage and are {@condition poisoned} for 1 hour. Creatures who succeed take half damage and are not {@condition poisoned}.",
 				"A DC 20 Intelligence ({@skill Investigation}) check allows a character to deduce the trap's presence from alterations made to the lock to accommodate the nozzle and vial. A DC 15 Dexterity check using {@item thieves' tools|phb} disarms the trap, removing the nozzle and gas vial from the lock. Unsuccessfully attempting to pick the lock triggers the trap.",
-				"A DM can choose to have a different kind of {@filter inhaled poison|items|source=null|type=poison|search=inhaled} ({@book Dungeon Master's Guide page 257\u2013258|dmg|8|poisons}) within the lock. The effects and save DC for the poison change as appropriate."
+				"A DM can choose to have a different kind of {@filter inhaled poison|items|source=null|type=poison|search=inhaled} ({@book Dungeon Master's Guide page 257–258|dmg|8|poisons}) within the lock. The effects and save DC for the poison change as appropriate."
 			]
 		},
 		{
@@ -196,7 +196,7 @@
 			"entries": [
 				"This 20-foot-square area has been cursed with a ritual that forms tendrils of pure necrotic energy that hunger to feed on the living. The ritual is powered by an unholy symbol painted or carved into the ground at the center of the area. The tendrils live below the surface of the floor and wait for a living creature to walk into the area before attacking.",
 				"A character notices the trapped area and its immediate surroundings are slightly colder with a DC 10 Wisdom ({@skill Perception}) check. A character trained in {@skill Religion} can determine the meaning of the symbol with a DC 15 Intelligence ({@skill Religion}) check.",
-				"When a creature steps into the area, the tendrils rise from the ground and make an attack roll against that creature with a {@atk 8|+8 bonus}. On a hit the tendrils deal 22 ({@dice 4d10}) necrotic damage and the target is {@condition grappled} (escape DC 15). While {@condition grappled} in this way the target is also {@condition restrained}. The tendrils make new attacks at the start of each round against any creature in the area.",
+				"When a creature steps into the area, the tendrils rise from the ground and make an attack roll against that creature with a {@hit 8|+8 bonus}. On a hit the tendrils deal 22 ({@dice 4d10}) necrotic damage and the target is {@condition grappled} (escape DC 15). While {@condition grappled} in this way the target is also {@condition restrained}. The tendrils make new attacks at the start of each round against any creature in the area.",
 				"Dealing 15 damage to the tendrils grasping a creature with a single attack or spell causes the arms to let go of that creature (AC 15). Dealing any radiant damage to the tendrils causes them to disappear."
 			]
 		},
@@ -208,7 +208,7 @@
 			"entries": [
 				"Hidden behind a wall, this circular saw blade with a 5-foot-radius runs along a track in the wall, floor, or ceiling after a tripwire is activated.",
 				"The tripwire is 3 inches off the ground and stretches between two columns. A successful DC 15 Wisdom ({@skill Perception}) check spots the tripwire or the blades hidden deep within a slot in the walls. A DC 10 Wisdom ({@skill Perception}) check notices the deep grooves in the wall, ceiling, or floor that serve as the saw's track. A DC 15 Dexterity check made with {@item thieves' tools|phb} breaks the tripwire harmlessly. A character without {@item thieves' tools|phb}can attempt this check with disadvantage using any edged weapon or tool. On a failed check the trap triggers.",
-				"Once the trap is activated the saw moves 40 feet along its track at the start of a round. The saw makes an attack roll with a {@atk 6|+6 bonus} against any creature in its path. On a hit the creature takes 11 ({@dice 2d10}) slashing damage. If the saw gets to the end of its track, it switches direction and comes back the other way.",
+				"Once the trap is activated the saw moves 40 feet along its track at the start of a round. The saw makes an attack roll with a {@hit 6|+6 bonus} against any creature in its path. On a hit the creature takes 11 ({@dice 2d10}) slashing damage. If the saw gets to the end of its track, it switches direction and comes back the other way.",
 				"Some tripwires are triggered to activate multiple saws in a room or hall, each of which runs along a different track and gets to make its own attacks at the start of the round."
 			]
 		},


### PR DESCRIPTION
`@hit` tags were (auto-?)converted to `@atk` tags for some reason, when what was desired was a d20+mod attack roll.